### PR TITLE
Added version string to output file name

### DIFF
--- a/overlay/Config.in
+++ b/overlay/Config.in
@@ -3,5 +3,17 @@ config RXOS_OVERLAY_NAME
 	help
 	  Name of the overlay that will be used in the
 	  output file. The overlay file name will be 
-	  overlay-<name>.sqfs. Do not include spaces
-	  in the name.
+	  overlay-<name>-<version>.sqfs. 
+	  
+	  DO NOT INCLUDE SPACES OR DASHES IN THE NAME.
+
+
+config RXOS_OVERLAY_VERSION
+	string "Overlay version"
+	help
+	  Version of the overlay that will be used in the
+	  output file. The overlay file name will be 
+	  overlay-<name>-<version>.sqfs. If the version
+	  is left blank, current date will be used instead.
+
+	  DO NOT INCLUDE SPACES OR DASHES IN THE VERSION.

--- a/overlay/external.mk
+++ b/overlay/external.mk
@@ -3,4 +3,11 @@ include $(sort $(wildcard $(BR2_EXTERNAL)/package/*/*.mk))
 # Disable any and all target finalize hooks
 TARGET_FINALIZE_HOOKS =
 
-BR2_ROOTFS_POST_SCRIPT_ARGS = $(call qstrip,$(RXOS_OVERLAY_NAME))
+ifndef RXOS_OVERLAY_VERSION
+VERSION_STRING = $(shell date '+%Y%m%d')
+else
+VERSION_STRING = $(call qstrip,$(RXOS_OVERLAY_VERSION))
+endif
+
+BR2_ROOTFS_POST_SCRIPT_ARGS = $(call qstrip,$(RXOS_OVERLAY_NAME)) \
+							  $(VERSION_STRING)

--- a/overlay/scripts/dedupe.sh
+++ b/overlay/scripts/dedupe.sh
@@ -3,10 +3,11 @@
 set -e
 
 OVERLAY_NAME="$2"
+OVERLAY_VERSION="$3"
 DEDUPE_SCRIPT="$BR2_EXTERNAL/scripts/dedupe.py"
 DELETE_LIST="$BR2_EXTERNAL/configs/delete_list.txt"
 ROOTFS_TARBALL="$BINARIES_DIR/rootfs.tar"
-OUTPUT="$BINARIES_DIR/overlay-${OVERLAY_NAME}.sqfs"
+OUTPUT="$BINARIES_DIR/overlay-${OVERLAY_NAME}-${OVERLAY_VERSION}.sqfs"
 UNPACK_DIR="/tmp/overlay-$(date +%s)"
 
 mkdir -p "$UNPACK_DIR"


### PR DESCRIPTION
Since overlays may need to be updated automatically, a version string is
appended to overlay file name to allow for this. A new rule is introduced for
overlay name and version string: no space or dashes allowed.
